### PR TITLE
Make more parse errors raise `SyntaxError`

### DIFF
--- a/lib/rkelly/parser.rb
+++ b/lib/rkelly/parser.rb
@@ -46,7 +46,7 @@ module RKelly
     end
 
     def yyabort
-      raise "something bad happened, please report a bug with sample JavaScript"
+      raise RKelly::SyntaxError, 'something bad happened, please report a bug with sample JavaScript'
     end
 
     # When parsing finishes without all tokens being parsed, returns

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1431,4 +1431,10 @@ class ParserTest < Test::Unit::TestCase
   def for_loop_sexp(init, test = [:less, [:resolve, 'foo'], [:lit, 10]], exec = [:postfix, [:resolve, 'foo'], '++'])
     [[:for, init, test, exec, [:block, [[:var, [[:var_decl, :x, [:assign, [:lit, 10]]]]]]]]]
   end
+
+  def test_stray_brackets_raise_syntax_error
+    assert_raises(RKelly::SyntaxError) do
+      RKelly::Parser.new.parse "var a, []"
+    end
+  end
 end


### PR DESCRIPTION
Since I often use RKelly to determine whether a piece of JavaScript is valid, it's not uncommon to hit unusual syntactically invalid cases, like this one which is distilled down to `var a, []`.  I would like to improve the way these errors are reported.

This PR makes `yyabort` raise a `SyntaxError` rather than a `RuntimeError`, which makes it easier for me to catch parsing failures due to invalid JavaScript.  However, I don't know if this also inhibits some actual assertions that should result in a different error.  Feedback appreciated.