### PR TITLE
allow octal numbers for JSDuck

### DIFF
--- a/lib/rkelly/tokenizer.rb
+++ b/lib/rkelly/tokenizer.rb
@@ -131,7 +131,7 @@ module RKelly
         value.gsub!(/^\./, '0.') if value =~ /^\./
         [type, eval(value)]
       end
-      token(:NUMBER, /0[xX][\da-fA-F]+|0[0-7]*|\d+/, digits) do |type, value|
+      token(:NUMBER, /0[xX][\da-fA-F]+|0[oO][0-7]+|0[0-7]*|\d+/, digits) do |type, value|
         [type, eval(value)]
       end
 


### PR DESCRIPTION
Using the JSDuck, and octal numbers (e.g., 0o0400) were causing a parse failure.