### PR TITLE
allow unicode and sticky regex modifier for JSDuck

### DIFF
--- a/lib/rkelly/tokenizer.rb
+++ b/lib/rkelly/tokenizer.rb
@@ -167,7 +167,7 @@ module RKelly
                                         (?# only \ and ] have to be escaped here )
              )+
 
-             /[gim]*            (?# ending + modifiers )
+             /[gimuy]*          (?# ending + modifiers )
       }x, ['/'])
 
       literal_chars = LITERALS.keys.map {|k| k.slice(0,1) }.uniq


### PR DESCRIPTION
Using the JSDuck and the 'u' regex modifier was causing a parse failure. I added the 'y' regex modifier while there.