### PR TITLE
ECMA: Indent Multi-line Closing Brace for ObjectLiteralNode

### DIFF
--- a/lib/rkelly/visitors/ecma_visitor.rb
+++ b/lib/rkelly/visitors/ecma_visitor.rb
@@ -257,9 +257,10 @@ module RKelly
         @indent += 1
         lit = "{" + (o.value.length > 0 ? "\n" : ' ') +
           o.value.map { |x| "#{indent}#{x.accept(self)}" }.join(",\n") +
-          (o.value.length > 0 ? "\n" : '') + '}'
-        @indent -= 1
-        lit
+          begin
+            @indent -= 1
+            (o.value.length > 0 ? "\n#{indent}}" : '}')
+          end
       end
 
       def visit_PropertyNode(o)


### PR DESCRIPTION
```
puts RKelly.parse('return { a: 5, b: {c: 4, d: { e: a } } }').to_ecma
return {
  a: 5,
  b: {
    c: 4,
    d: {
      e: a
}
}
};
```
To
```
puts RKelly.parse('return { a: 5, b: {c: 4, d: { e: a } } }').to_ecma
return {
  a: 5,
  b: {
    c: 4,
    d: {
      e: a
    }
  }
};
```